### PR TITLE
Adding queryable "author" field to Posts and BasicProfile

### DIFF
--- a/composites/00-basicProfile.graphql
+++ b/composites/00-basicProfile.graphql
@@ -1,4 +1,5 @@
 type BasicProfile @createModel(accountRelation: SINGLE, description: "A basic Profile") {
+  author: DID! @documentAccount 
   name: String! @string(minLength: 3, maxLength: 100)
   username: String! @string(minLength: 5, maxLength: 255)
   description: String @string(minLength: 3, maxLength: 100)

--- a/composites/01-posts.graphql
+++ b/composites/01-posts.graphql
@@ -7,6 +7,7 @@ type Posts
     @createIndex(fields: [{ path: "created" }])
     @createIndex(fields: [{ path: "edited" }])
     @createIndex(fields: [{ path: "tag" }]) {
+    author: DID! @documentAccount 
     body: String! @string(minLength: 1, maxLength: 100)
     tag: String! @string(minLength: 1, maxLength: 100)
     edited: DateTime


### PR DESCRIPTION
Adding queryable "author" field to Posts and BasicProfile to coincide with the API Sandbox and most recent corresponding changes: https://github.com/ceramicstudio/js-composedb/pull/177